### PR TITLE
Fix finding stacks that does not exist in Jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build.py
 .cache
 .venv
 run.sh
+__pycache__
+.tox/

--- a/lizzy/exceptions.py
+++ b/lizzy/exceptions.py
@@ -1,4 +1,3 @@
-
 from typing import Union
 
 

--- a/lizzy/job/__init__.py
+++ b/lizzy/job/__init__.py
@@ -23,6 +23,7 @@ from lizzy.apps.senza import Senza
 from lizzy.apps.common import ExecutionError
 from lizzy.job.deployer import Deployer
 from lizzy.models.stack import Stack
+from lizzy.exceptions import ObjectNotFound
 
 try:
     # From http://uwsgi-docs.readthedocs.org/en/latest/PythonModule.html
@@ -55,7 +56,7 @@ def check_status(region: str):
             logger.debug("Stack found.", extra={'lizzy.stack.id': stack_name})
             lizzy_stacks[lizzy_stack.stack_name][lizzy_stack.stack_version] = lizzy_stack
             cf_stacks[lizzy_stack.stack_name][lizzy_stack.stack_version] = cf_stack
-        except KeyError:
+        except ObjectNotFound:
             # Stack no handled by lizzy
             pass
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, call, ANY
 
 from lizzy.apps.common import ExecutionError
 from lizzy.job import check_status
+from lizzy.exceptions import ObjectNotFound
 
 SENZA_STACKS = [{'stack_name': 'stack', 'version': 1},
                 {'stack_name': 'stacknotinlizzy', 'version': 1},
@@ -41,7 +42,10 @@ class FakeStack:
 
     @classmethod
     def get(cls, item):
-        return cls(**LIZZY_STACKS[item])
+        try:
+            return cls(**LIZZY_STACKS[item])
+        except KeyError:
+            raise ObjectNotFound(item)
 
     def lock(self, n):
         return True

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,8 @@
 [flake8]
 max-line-length = 120
+
+[tox]
+envlist=py35
+
+[testenv]
+commands=python setup.py test


### PR DESCRIPTION
The get method in [`Stack`](https://github.com/zalando/lizzy/blob/master/lizzy/models/stack.py#L88)s object now throw a `ObjectNotFound` exception when the stack does not exist. An error was caused because the code was not updated in [`jobs/__init__.py`](https://github.com/zalando/lizzy/blob/master/lizzy/job/__init__.py#L58) to catch `ObjectNotFound` exception and it was catching the `KeyError` exception that was being thrown in that case in the old versions of Lizzy.

What changed:
- Replaced the exception `KeyError` by `ObjectNotFound`
- Added testing target to `tox.ini` file
- Added `__pycache__` and `.tox/` to `.gitignore` file