### PR TITLE
Tag Lizzy version in newly created stacks

### DIFF
--- a/lizzy/apps/senza.py
+++ b/lizzy/apps/senza.py
@@ -6,8 +6,6 @@ from .common import Application
 from ..exceptions import (ExecutionError, SenzaDomainsError, SenzaTrafficError,
                           SenzaRespawnInstancesError, SenzaPatchError)
 
-TAG_CLI_FLAG = '-t'
-
 
 class Senza(Application):
     def __init__(self, region: str):
@@ -32,8 +30,7 @@ class Senza(Application):
                 if disable_rollback:
                     args.append('--disable-rollback')
 
-                parameters.append(TAG_CLI_FLAG)
-                parameters.append('LizzyVersion={}'.format(VERSION))
+                parameters.extend(['-t', 'LizzyVersion={}'.format(VERSION)])
 
                 self._execute('create', *args, temp_yaml.name, stack_version,
                               image_version, *parameters)
@@ -46,16 +43,18 @@ class Senza(Application):
 
     def domains(self, stack_name: Optional[str]=None) -> List[Dict[str, str]]:
         """
-        Get domain names for applications. If stack name is provided then it will show the domain names just for that
-        application
+        Get domain names for applications. If stack name is provided then it
+        will show the domain names just for that application
 
         :param stack_name: Name of the application stack
         :return: Route53 Domains
-        :raises SenzaDomainError: when a ExecutionError is thrown to allow more specific error handing.
+        :raises SenzaDomainError: when a ExecutionError is thrown to allow more
+                                  specific error handing.
         """
         try:
             if stack_name:
-                stack_domains = self._execute('domains', stack_name, expect_json=True)
+                stack_domains = self._execute('domains', stack_name,
+                                              expect_json=True)
             else:
                 stack_domains = self._execute('domains', expect_json=True)
             return stack_domains

--- a/lizzy/swagger/lizzy.yaml
+++ b/lizzy/swagger/lizzy.yaml
@@ -264,7 +264,7 @@ definitions:
         description: Docker image version of the stack
       parameters:
         type: array
-        description: List of parameters to passed to senza
+        description: List of parameters to be passed to senza
         items:
           type: string
       senza_yaml:

--- a/lizzy/version.py
+++ b/lizzy/version.py
@@ -1,2 +1,2 @@
 # Version to be checked on the client
-VERSION = '1.4.2'
+VERSION = '1.4'

--- a/lizzy/version.py
+++ b/lizzy/version.py
@@ -1,2 +1,2 @@
 # Version to be checked on the client
-VERSION = '2016-02-22'
+VERSION = '1.4.2'

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ from setuptools.command.test import test as TestCommand
 
 _version_re = re.compile(r'VERSION\s+=\s+(.*)')
 
+MINOR_VERSION = 2
+
 with open('lizzy/version.py', 'rb') as f:
     version_content = f.read().decode('utf-8')
     VERSION = ast.literal_eval(_version_re.search(version_content).group(1))
@@ -45,7 +47,7 @@ class PyTest(TestCommand):
 setup(
     name='lizzy',
     packages=find_packages(),
-    version=VERSION,
+    version='{}.{}'.format(VERSION, MINOR_VERSION),
     description='REST Service to deploy AWS CF templates using Senza',
     long_description=get_long_description(),
     author='Zalando SE',

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-
+import re
+import ast
 import sys
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-# The minor and major versions should match lizzy's version
-VERSION_MAJOR = 1
-VERSION_MINOR = 4
-REVISION = 2
-VERSION = '{VERSION_MAJOR}.{VERSION_MINOR}.{REVISION}'.format_map(locals())
+_version_re = re.compile(r'VERSION\s+=\s+(.*)')
+
+with open('lizzy/version.py', 'rb') as f:
+    version_content = f.read().decode('utf-8')
+    VERSION = ast.literal_eval(_version_re.search(version_content).group(1))
 
 
 def get_long_description():

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
                       'pyyaml',
                       'rod',
                       'stups-kio',
-                      'stups-senza',
+                      'stups-senza>=1.0.40',
                       'uwsgi',
                       'uwsgi_metrics3'],
     tests_require=['pytest-cov', 'pytest'],

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,8 +9,9 @@ from lizzy.models.stack import Stack
 from lizzy.exceptions import (ObjectNotFound, AMIImageNotUpdated,
                               TrafficNotUpdated)
 from lizzy.service import setup_webapp
+from lizzy.version import VERSION
 
-CURRENT_VERSION = '2016-02-22'
+CURRENT_VERSION = VERSION
 
 GOOD_HEADERS = {'Authorization': 'Bearer 100', 'Content-type': 'application/json'}
 


### PR DESCRIPTION
Solve #31.

While creating new stacks using Senza, Lizzy will add a tag marking which version of Lizzy was used to deploy the stack. That is good for debug and clearly know which CloudFormation stacks are being deployed with Lizzy.

What changed:
- Added `-t LizzyVersion={version}` to the `senza create` command executed by Lizzy
- Added a dependency of newer versions of Senza to be used with Lizzy (>=1.0.40)