### PR TITLE
Fix call to parent class method on Stack

### DIFF
--- a/lizzy/job/__init__.py
+++ b/lizzy/job/__init__.py
@@ -32,7 +32,7 @@ def check_status(region: str):
         senza_list = senza.list()  # All stacks in senza
     except ExecutionError:
         logger.exception("Couldn't get CF stacks. Exiting Job.")
-        return
+        return False
 
     logger.debug('Got %d senza stacks.', len(senza_list),
                  extra={'senza_stacks': senza_list})

--- a/lizzy/job/deployer.py
+++ b/lizzy/job/deployer.py
@@ -47,14 +47,16 @@ class Deployer:
         longer exists.
         """
 
-        self.logger.debug("Updating stack status based on AWS CF.", extra=self.log_info)
+        self.logger.debug("Updating stack status based on AWS CF.",
+                          extra=self.log_info)
         cloud_formation_status = self._get_stack_status()
         if cloud_formation_status is not None:
             self.logger.debug("Stack status updated", extra=self.log_info)
             new_status = 'CF:{}'.format(cloud_formation_status)
         else:
             # If this happens is because the stack was removed from aws
-            self.logger.info("Stack no longer exists, marking as removed", extra=self.log_info)
+            self.logger.info("Stack no longer exists, marking as removed",
+                             extra=self.log_info)
             new_status = 'LIZZY:REMOVED'
         return new_status
 

--- a/lizzy/models/stack.py
+++ b/lizzy/models/stack.py
@@ -87,6 +87,6 @@ class Stack(rod.model.Model):
     @classmethod
     def get(cls, *args, **kwargs):
         try:
-            rod.model.Model.get(*args, **kwargs)
+            super().get(*args, **kwargs)
         except KeyError:
             raise ObjectNotFound(args[0])

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools.command.test import test as TestCommand
 # The minor and major versions should match lizzy's version
 VERSION_MAJOR = 1
 VERSION_MINOR = 4
-REVISION = 1
+REVISION = 2
 VERSION = '{VERSION_MAJOR}.{VERSION_MINOR}.{REVISION}'.format_map(locals())
 
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -84,8 +84,10 @@ def test_check_status(monkeypatch):
     assert mock_deployer.handle.call_count == 1
 
     mock_log.debug.assert_any_call("In Job")
-    mock_log.debug.assert_any_call('Stack found.', extra={'lizzy.stack.id': 'stack-1'})
-    mock_log.debug.assert_any_call('Stack found.', extra={'lizzy.stack.id': 'lizzyremoved-1'})
+    mock_log.debug.assert_any_call('Stack found in Redis.',
+                                   extra={'lizzy.stack.id': 'stack-1'})
+    mock_log.debug.assert_any_call('Stack found in Redis.',
+                                   extra={'lizzy.stack.id': 'lizzyremoved-1'})
 
 
 def test_fail_get_list(monkeypatch):


### PR DESCRIPTION
Using `rod.model.Model.get(*args, **kwargs)` instead of `super().get(*args, **kwargs)` meant `Lizzy` was using the wrong prefix.