### PR TITLE
Sort stacks by creation time

### DIFF
--- a/lizzy/job/deployer.py
+++ b/lizzy/job/deployer.py
@@ -113,7 +113,11 @@ class Deployer:
             except ExecutionError:
                 self.logger.exception("Failed to switch app traffic.", extra=self.log_info)
 
-        all_versions = sorted(self.lizzy_stacks[self.stack.stack_name].keys())
+        all_versions = sorted(
+            self.lizzy_stacks[self.stack.stack_name].values(),
+            key=lambda s: s.creation_time)
+        all_versions = [stack.stack_name for stack in all_versions]
+
         self.logger.debug("Existing versions: %s", all_versions, extra=self.log_info)
         # we want to keep only two versions
         number_of_versions_to_keep = self.stack.keep_stacks + 1  # keep provided old stacks + 1

--- a/lizzy/job/deployer.py
+++ b/lizzy/job/deployer.py
@@ -116,12 +116,12 @@ class Deployer:
         all_versions = sorted(
             self.lizzy_stacks[self.stack.stack_name].values(),
             key=lambda s: s.creation_time)
-        all_versions = [stack.stack_name for stack in all_versions]
+        all_versions_names = [stack.stack_name for stack in all_versions]
 
-        self.logger.debug("Existing versions: %s", all_versions, extra=self.log_info)
+        self.logger.debug("Existing versions: %s", all_versions_names, extra=self.log_info)
         # we want to keep only two versions
         number_of_versions_to_keep = self.stack.keep_stacks + 1  # keep provided old stacks + 1
-        versions_to_remove = all_versions[:-number_of_versions_to_keep]
+        versions_to_remove = all_versions_names[:-number_of_versions_to_keep]
         self.logger.debug("Versions to be removed: %s", versions_to_remove, extra=self.log_info)
         for version in versions_to_remove:
             stack_id = '{}-{}'.format(self.stack.stack_name, version)

--- a/lizzy/models/stack.py
+++ b/lizzy/models/stack.py
@@ -1,5 +1,6 @@
 from typing import Optional  # NOQA
 from datetime import datetime
+from dateutil import parser as date_parser
 import rod.model
 from lizzy.exceptions import ObjectNotFound
 
@@ -44,7 +45,7 @@ class Stack(rod.model.Model):
         :param kwargs: Other parameters that are not recognized
         """
         self.stack_name = stack_name
-        self.creation_time = creation_time or now()  # type: datetime
+        self.creation_time = self._parse_date(creation_time or now())  # type: datetime
         self.image_version = image_version
         self.stack_version = (stack_version or
                               application_version or
@@ -83,6 +84,11 @@ class Stack(rod.model.Model):
         parameters = [self.image_version]
         parameters.extend(self.parameters)
         return SenzaDefinition(self.senza_yaml, parameters)
+
+    def _parse_date(self, date_time):
+        if isinstance(date_time, datetime):
+            return date_time
+        return date_parser.parse(date_time)
 
     @classmethod
     def get(cls, *args, **kwargs) -> "Stack":

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools.command.test import test as TestCommand
 
 _version_re = re.compile(r'VERSION\s+=\s+(.*)')
 
-MINOR_VERSION = 0
+MINOR_VERSION = 1
 
 with open('lizzy/version.py', 'rb') as f:
     version_content = f.read().decode('utf-8')

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
                       'stups-senza>=1.0.40',
                       'uwsgi',
                       'uwsgi_metrics3'],
-    tests_require=['pytest-cov', 'pytest'],
+    tests_require=['pytest-cov', 'pytest', 'factory_boy'],
     cmdclass={'test': PyTest},
     classifiers=[
         'Programming Language :: Python',


### PR DESCRIPTION
Fix #73

Stacks have been sorted by version name. We should find old stacks by creation time. If we would use version numbers to delete old stacks, I would recommend to use [`from distutils.version import LooseVersion`](http://stackoverflow.com/a/11887885) that handles free form versions nicely.