### PR TITLE
Support named params

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,8 @@ Lizzy
 
 **DISCLAIMER: Lizzy is still in alpha state.**
 
-REST Service to deploy AWS CF templates using Senza.
+REST Service to deploy AWS Cloud Formation templates using `Senza`_
+CLI tool.
 
 
 Configuration
@@ -71,3 +72,5 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+.. _Senza: https://github.com/zalando-stups/senza

--- a/lizzy/api.py
+++ b/lizzy/api.py
@@ -11,7 +11,8 @@ from lizzy.models.stack import Stack
 from lizzy.security import bouncer
 from lizzy.version import VERSION
 from lizzy.exceptions import (ObjectNotFound, AMIImageNotUpdated,
-                              TrafficNotUpdated, StackDeleteException)
+                              TrafficNotUpdated, StackDeleteException,
+                              SenzaRenderError)
 from lizzy.deployer import InstantDeployer
 from lizzy.util import filter_empty_values
 
@@ -76,31 +77,28 @@ def create_stack(new_stack: dict) -> dict:
     senza_yaml = new_stack['senza_yaml']  # type: str
     parameters = new_stack.get('parameters', [])
     disable_rollback = new_stack.get('disable_rollback', False)
+    stack_name = None
+    artifact_name = None
+    cf_raw_definition = None
+    senza = Senza(config.region)
 
     try:
-        senza_definition = yaml.safe_load(senza_yaml)
-        if not isinstance(senza_definition, dict):
-            raise TypeError
-    except yaml.YAMLError:
-        logger.exception("Couldn't parse senza yaml.",
-                         extra={'senza_yaml': repr(senza_yaml)})
+        cf_raw_definition = senza.render_definition(senza_yaml, stack_version,
+                                                    image_version, parameters)
+    except SenzaRenderError as exception:
         return connexion.problem(400,
                                  'Invalid senza yaml',
-                                 "Failed to parse senza yaml.",
-                                 headers=_make_headers())
-    except TypeError:
-        logger.exception("Senza yaml is not a dict.",
-                         extra={'senza_yaml': repr(senza_yaml)})
-        return connexion.problem(400,
-                                 'Invalid senza yaml',
-                                 "Senza yaml is not a dict.",
+                                 exception.message,
                                  headers=_make_headers())
 
     try:
-        stack_name = senza_definition['SenzaInfo']['StackName']  # type: str
+        stack_name = cf_raw_definition['Mappings']['Senza']['Info']['StackName']
+        taupage_yaml = cf_raw_definition['Resources']['AppServerConfig']['Properties']['UserData']
+        taupage_config = yaml.safe_load(taupage_yaml)
+        artifact_name = taupage_config['source']
     except KeyError as exception:
         logger.error("Couldn't get stack name from definition.",
-                     extra={'senza_yaml': repr(senza_definition)})
+                     extra={'senza_yaml': repr(cf_raw_definition)})
         missing_property = str(exception)
         problem = connexion.problem(400,
                                     'Invalid senza yaml',
@@ -118,12 +116,10 @@ def create_stack(new_stack: dict) -> dict:
                   stack_version=stack_version,
                   application_version=application_version,
                   parameters=parameters)
-    definition = stack.generate_definition()
+
     if stack.application_version:
         kio_extra = {'stack_name': stack_name, 'version': application_version}
         logger.info("Registering version on kio...", extra=kio_extra)
-        taupage_config = definition.app_server.get('TaupageConfig', {})  # type: Dict[str, str]
-        artifact_name = taupage_config.get('source', '')
         kio = Kio()
         if kio.versions_create(application_id=stack.stack_name,
                                version=stack.application_version,

--- a/lizzy/api.py
+++ b/lizzy/api.py
@@ -98,7 +98,7 @@ def create_stack(new_stack: dict) -> dict:
         artifact_name = taupage_config['source']
     except KeyError as exception:
         logger.error("Couldn't get stack name from definition.",
-                     extra={'senza_yaml': repr(cf_raw_definition)})
+                     extra={'cf_definition': repr(cf_raw_definition)})
         missing_property = str(exception)
         problem = connexion.problem(400,
                                     'Invalid senza yaml',

--- a/lizzy/api.py
+++ b/lizzy/api.py
@@ -56,7 +56,7 @@ def all_stacks() -> dict:
     """
     GET /stacks/
     """
-    stacks = [(_get_stack_dict(stack)) for stack in Stack.all()]
+    stacks = [_get_stack_dict(stack) for stack in Stack.all()]
     stacks.sort(key=lambda stack: stack['creation_time'])
     return stacks, 200, _make_headers()
 
@@ -93,7 +93,7 @@ def create_stack(new_stack: dict) -> dict:
 
     try:
         stack_name = cf_raw_definition['Mappings']['Senza']['Info']['StackName']
-        taupage_yaml = cf_raw_definition['Resources']['AppServerConfig']['Properties']['UserData']
+        taupage_yaml = cf_raw_definition['Resources']['AppServerConfig']['Properties']['UserData']['Fn::Base64']
         taupage_config = yaml.safe_load(taupage_yaml)
         artifact_name = taupage_config['source']
     except KeyError as exception:

--- a/lizzy/exceptions.py
+++ b/lizzy/exceptions.py
@@ -43,6 +43,10 @@ class SenzaPatchError(ExecutionError):
     """Raised when `senza patch` command returns an unexpected error."""
 
 
+class SenzaRenderError(Exception):
+    """Raised when not possible to render CloudFormation file."""
+
+
 class ObjectNotFound(LizzyError):
     """Raised when model instance is not found in storage."""
 

--- a/lizzy/exceptions.py
+++ b/lizzy/exceptions.py
@@ -43,7 +43,7 @@ class SenzaPatchError(ExecutionError):
     """Raised when `senza patch` command returns an unexpected error."""
 
 
-class SenzaRenderError(Exception):
+class SenzaRenderError(ExecutionError):
     """Raised when not possible to render CloudFormation file."""
 
 

--- a/tests/fixtures/cloud_formation.py
+++ b/tests/fixtures/cloud_formation.py
@@ -1,0 +1,47 @@
+GOOD_CF_DEFINITION = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Mappings": {
+        "Senza": {
+            "Info": {
+                "StackName": "abc",
+                "StackVersion": "2"
+            }
+        }
+    },
+    "Parameters": {},
+    "Resources": {
+        "AppServerConfig": {
+            "Properties": {
+                "ImageId": "image-id",
+                "InstanceType": "t2.micro",
+                "UserData": {
+                    "Fn::Base64": "#taupage-config\napplication_id: abc\nsource: pierone.example.com/lizzy/lizzy:12\n"
+                }
+            },
+            "Type": "AWS::AutoScaling::LaunchConfiguration"
+        }
+    }
+}
+
+BAD_CF_DEFINITION = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Mappings": {
+        "Senza": {
+            "Info": {
+                "StackName": "abc",
+                "StackVersion": "2"
+            }
+        }
+    },
+    "Parameters": {},
+    "Resources": {
+        "AppServerConfig": {
+            "Properties": {
+                "ImageId": "image-id",
+                "InstanceType": "t2.micro",
+                "UserData": {}
+            },
+            "Type": "AWS::AutoScaling::LaunchConfiguration"
+        }
+    }
+}

--- a/tests/fixtures/senza_definitions.py
+++ b/tests/fixtures/senza_definitions.py
@@ -1,0 +1,39 @@
+YAML1 = """
+SenzaInfo:
+  Parameters:
+  - ImageVersion: {Description: Docker image version of lizzy.}
+  StackName: lizzy
+Test: lizzy:{{Arguments.ImageVersion}}
+SenzaComponents:
+- Configuration: {Type: 'Senza::StupsAutoConfiguration'}
+- AppServer:
+    AssociatePublicIpAddress: false
+    ElasticLoadBalancer: AppLoadBalancer
+    IamRoles: [app-lizzy-bus]
+    InstanceType: t2.micro
+    SecurityGroups: [app-lizzy-bus]
+    TaupageConfig:
+      application_version: '{{Arguments.ImageVersion}}'
+      health_check_path: /api/swagger.json
+      ports: {8080: 8080}
+      runtime: Docker
+      source: lizzy:{{Arguments.ImageVersion}}
+    Type: Senza::TaupageAutoScalingGroup
+"""
+
+YAML2 = """
+SenzaInfo:
+  Parameters:
+  - ImageVersion: {Description: Docker image version of lizzy.}
+  - Test1:  {Description: test}
+  - Test2:  {Description: test}
+  StackName: lizzy
+Test: lizzy:{{Arguments.ImageVersion}}
+Test2: test-{{Arguments.Test1}}
+"""
+
+INVALID_YAML = """
+- SenzaInfo:
+   - Parameters:
+     Name: "Something"
+"""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,9 +7,12 @@ import requests
 import lizzy.api
 from lizzy.models.stack import Stack
 from lizzy.exceptions import (ObjectNotFound, AMIImageNotUpdated,
-                              TrafficNotUpdated, StackDeleteException)
+                              TrafficNotUpdated, StackDeleteException,
+                              SenzaRenderError)
 from lizzy.service import setup_webapp
 from lizzy.version import VERSION
+
+from fixtures.cloud_formation import GOOD_CF_DEFINITION, BAD_CF_DEFINITION
 
 CURRENT_VERSION = VERSION
 
@@ -127,25 +130,34 @@ def test_empty_new_stack(monkeypatch, app, oauth_requests):
     assert response['title'] == 'Bad Request'
 
 
-def test_bad_senza_yaml(app, oauth_requests):
+def test_bad_senza_yaml(app, oauth_requests, monkeypatch):
     data = {'keep_stacks': 0,
             'new_traffic': 100,
             'image_version': '1.0',
             'senza_yaml': 'key: value'}
 
+    mock_senza = MagicMock()
+    mock_senza.return_value = mock_senza
+    monkeypatch.setattr('lizzy.api.Senza', mock_senza)
+    mock_senza.render_definition.side_effect = SenzaRenderError("Some error", "output error")
+
     request = app.post('/api/stacks', headers=GOOD_HEADERS, data=json.dumps(data))  # type: flask.Response
     assert request.status_code == 400
     response = json.loads(request.data.decode())
     assert response['title'] == 'Invalid senza yaml'
-    assert response['detail'] == "Missing property in senza yaml: 'SenzaInfo'"
     assert request.headers['X-Lizzy-Version'] == CURRENT_VERSION
+
+    mock_senza = MagicMock()
+    mock_senza.return_value = mock_senza
+    monkeypatch.setattr('lizzy.api.Senza', mock_senza)
+    mock_senza.render_definition.return_value = BAD_CF_DEFINITION
 
     data['senza_yaml'] = '[]'
     request = app.post('/api/stacks', headers=GOOD_HEADERS, data=json.dumps(data))  # type: flask.Response
     assert request.status_code == 400
     response = json.loads(request.data.decode())
     assert response['title'] == 'Invalid senza yaml'
-    assert response['detail'] == "Senza yaml is not a dict."
+    assert response['detail'] == "Missing property in senza yaml: 'Fn::Base64'"
     assert request.headers['X-Lizzy-Version'] == CURRENT_VERSION
 
 
@@ -161,7 +173,7 @@ def test_new_stack(monkeypatch, app, oauth_requests):
     mock_kio = MagicMock()
     mock_kio.return_value = mock_kio
     monkeypatch.setattr('lizzy.api.Kio', mock_kio)
-    mock_senza.render_definition.return_value = {}
+    mock_senza.render_definition.return_value = GOOD_CF_DEFINITION
 
     mock_senza.create.return_value = True
     request = app.post('/api/stacks', headers=GOOD_HEADERS, data=json.dumps(data))  # type: flask.Response
@@ -209,13 +221,14 @@ def test_new_stack(monkeypatch, app, oauth_requests):
             'parameters': ['abc', 'def'],
             'application_version': '42'}
     mock_senza.reset_mock()
+    mock_senza.render_definition.return_value = GOOD_CF_DEFINITION
     mock_kio.versions_create.return_value = True
     request = app.post('/api/stacks', headers=GOOD_HEADERS, data=json.dumps(data))  # type: flask.Response
     mock_senza.assert_called_with('eu-west-1')
     mock_senza.create.assert_called_with('SenzaInfo:\n  StackName: abc', ANY, '1.0', ['abc', 'def'], False)
     mock_kio.assert_called_with()
     mock_kio.versions_create.assert_called_once_with(application_id='abc',
-                                                     artifact='',
+                                                     artifact='pierone.example.com/lizzy/lizzy:12',
                                                      version='42')
     assert request.status_code == 201
     assert request.headers['X-Lizzy-Version'] == CURRENT_VERSION
@@ -230,6 +243,7 @@ def test_new_stack(monkeypatch, app, oauth_requests):
 
     mock_kio.reset_mock()
     mock_senza.reset_mock()
+    mock_senza.render_definition.return_value = GOOD_CF_DEFINITION
     data = {'keep_stacks': 0,
             'new_traffic': 100,
             'image_version': '1.0',
@@ -248,7 +262,7 @@ def test_new_stack(monkeypatch, app, oauth_requests):
                                          True)
     mock_kio.assert_called_with()
     mock_kio.versions_create.assert_called_once_with(application_id='abc',
-                                                     artifact='',
+                                                     artifact='pierone.example.com/lizzy/lizzy:12',
                                                      version='42')
     assert request.status_code == 201
     assert request.headers['X-Lizzy-Version'] == CURRENT_VERSION
@@ -269,7 +283,7 @@ def test_new_stack(monkeypatch, app, oauth_requests):
                        data=json.dumps(data))  # type: flask.Response
     mock_kio.assert_called_with()
     mock_kio.versions_create.assert_called_once_with(application_id='abc',
-                                                     artifact='',
+                                                     artifact='pierone.example.com/lizzy/lizzy:12',
                                                      version='42')
     assert request.status_code == 201
     assert request.headers['X-Lizzy-Version'] == CURRENT_VERSION
@@ -291,6 +305,7 @@ def test_new_stack(monkeypatch, app, oauth_requests):
     # Test creating stack with parameters to senza
     mock_senza.reset_mock()
     mock_senza.create.return_value = True
+    mock_senza.render_definition.return_value = GOOD_CF_DEFINITION
     mock_kio.versions_create.reset_mock()
     mock_kio.versions_create.return_value = True
     data = {'keep_stacks': 0,
@@ -308,20 +323,6 @@ def test_new_stack(monkeypatch, app, oauth_requests):
     stack_version = FakeStack.last_save['stack_version']
     assert FakeStack.last_save['parameters'] == ['MintBucket=bk-bucket',
                                                  'ImageVersion=28']
-
-
-def test_invalid_yaml(app, oauth_requests):
-    data = {'keep_stacks': 0,
-            'new_traffic': 100,
-            'image_version': '1.0',
-            'senza_yaml': '*invalid*yaml*file'}
-
-    request = app.post('/api/stacks', headers=GOOD_HEADERS, data=json.dumps(data))  # type: flask.Response
-    assert request.status_code == 400
-    response = json.loads(request.data.decode())  # type: dict
-    assert response['title'] == 'Invalid senza yaml'
-    assert response['detail'] == "Failed to parse senza yaml."
-    assert request.headers['X-Lizzy-Version'] == CURRENT_VERSION
 
 
 def test_get_stack(app, oauth_requests):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -287,6 +287,27 @@ def test_new_stack(monkeypatch, app, oauth_requests):
                        data=json.dumps(data))  # type: flask.Response
     assert request.status_code == 400
 
+    # Test creating stack with parameters to senza
+    mock_senza.reset_mock()
+    mock_senza.create.return_value = True
+    mock_kio.versions_create.reset_mock()
+    mock_kio.versions_create.return_value = True
+    data = {'keep_stacks': 0,
+            'new_traffic': 100,
+            'image_version': '1.0',
+            'senza_yaml': 'SenzaInfo:\n  StackName: abc',
+            'parameters': ['MintBucket=bk-bucket', 'ImageVersion=28']}
+
+    request = app.post('/api/stacks',
+                       headers=GOOD_HEADERS,
+                       data=json.dumps(data))
+    mock_senza.create.assert_called_with('SenzaInfo:\n  StackName: abc', ANY,
+                                         '1.0', ['MintBucket=bk-bucket',
+                                                 'ImageVersion=28'], False)
+    stack_version = FakeStack.last_save['stack_version']
+    assert FakeStack.last_save['parameters'] == ['MintBucket=bk-bucket',
+                                                 'ImageVersion=28']
+
 
 def test_invalid_yaml(app, oauth_requests):
     data = {'keep_stacks': 0,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -161,6 +161,7 @@ def test_new_stack(monkeypatch, app, oauth_requests):
     mock_kio = MagicMock()
     mock_kio.return_value = mock_kio
     monkeypatch.setattr('lizzy.api.Kio', mock_kio)
+    mock_senza.render_definition.return_value = {}
 
     mock_senza.create.return_value = True
     request = app.post('/api/stacks', headers=GOOD_HEADERS, data=json.dumps(data))  # type: flask.Response

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -10,44 +10,12 @@ from lizzy.exceptions import (SenzaPatchError, AMIImageNotUpdated,
                               SenzaDomainsError, SenzaTrafficError,
                               TrafficNotUpdated)
 
+from .fixtures.senza_definitions import YAML1
+
 
 CF_STACKS = {'lizzy': {'42': {'status': 'TEST'},
                        'inprog': {'status': 'CREATE_IN_PROGRESS'},
                        'deployed': {'status': 'CREATE_COMPLETE'}}}
-
-YAML1 = """
-SenzaInfo:
-  Parameters:
-  - ImageVersion: {Description: Docker image version of lizzy.}
-  StackName: lizzy
-Test: lizzy:{{Arguments.ImageVersion}}
-SenzaComponents:
-- Configuration: {Type: 'Senza::StupsAutoConfiguration'}
-- AppServer:
-    AssociatePublicIpAddress: false
-    ElasticLoadBalancer: AppLoadBalancer
-    IamRoles: [app-lizzy-bus]
-    InstanceType: t2.micro
-    SecurityGroups: [app-lizzy-bus]
-    TaupageConfig:
-      application_version: '{{Arguments.ImageVersion}}'
-      health_check_path: /api/swagger.json
-      ports: {8080: 8080}
-      runtime: Docker
-      source: lizzy:{{Arguments.ImageVersion}}
-    Type: Senza::TaupageAutoScalingGroup
-"""
-
-YAML2 = """
-SenzaInfo:
-  Parameters:
-  - ImageVersion: {Description: Docker image version of lizzy.}
-  - Test1:  {Description: test}
-  - Test2:  {Description: test}
-  StackName: lizzy
-Test: lizzy:{{Arguments.ImageVersion}}
-Test2: test-{{Arguments.Test1}}
-"""
 
 
 class StackFactory(Factory):

--- a/tests/test_deployer.py
+++ b/tests/test_deployer.py
@@ -10,7 +10,7 @@ from lizzy.exceptions import (SenzaPatchError, AMIImageNotUpdated,
                               SenzaDomainsError, SenzaTrafficError,
                               TrafficNotUpdated)
 
-from .fixtures.senza_definitions import YAML1
+from fixtures.senza_definitions import YAML1
 
 
 CF_STACKS = {'lizzy': {'42': {'status': 'TEST'},

--- a/tests/test_senza_wrapper.py
+++ b/tests/test_senza_wrapper.py
@@ -71,6 +71,19 @@ def test_create(monkeypatch, popen):
         'command.output': '{"stream": "stdout"}'
     })
 
+    popen.returncode = 0
+    senza.logger.reset_mock()
+    senza.create('yaml: yaml', '10', '42',
+                 ['Param1Here=Simple', 'ParamTwo=100'], False)
+
+    popen.assert_called_with(['senza', 'create',
+                              '--region', 'region',
+                              '--force', mock_tempfile.name,
+                              '10', '42', 'Param1Here=Simple', 'ParamTwo=100',
+                              '-t', lizzy_version_tag],
+                             stdout=-1,
+                             stderr=-2)
+
 
 def test_domain(monkeypatch, popen):
     senza = Senza('region')


### PR DESCRIPTION
Fix #70 

Seems like we already support passing named parameters to `senza` command. I just added some tests to make sure.