### PR TITLE
No error when app_version is None

### DIFF
--- a/lizzy/apps/common.py
+++ b/lizzy/apps/common.py
@@ -21,6 +21,7 @@ class Application:
         else:
             stderr_to = STDOUT
         command += args
+        command = [arg for arg in command if arg is not None]
         self.logger.debug('Executing %s.', self.application, extra={'command': ' '.join(command)})
         process = Popen(command, stdout=PIPE, stderr=stderr_to)
         stdout, _ = process.communicate()

--- a/tests/test_senza_wrapper.py
+++ b/tests/test_senza_wrapper.py
@@ -250,6 +250,10 @@ def test_render_definition(monkeypatch, popen):
     popen.assert_called_with(cmd.split(" "), stdout=-1, stderr=-1)
     assert not senza.logger.error.called
 
+    senza.render_definition('yaml content', None, 'imgversion22',
+                            ['Param1=app', 'SecondParam=3'])
+    assert not senza.logger.error.called
+
     # test error case
     popen.side_effect = ExecutionError('', '')
 


### PR DESCRIPTION
Fix #90

Some params may be `None` and should be ignored while running subcommands.