### PR TITLE
Fix rendering the cloudformation definition with generated versions

### DIFF
--- a/lizzy/api.py
+++ b/lizzy/api.py
@@ -82,9 +82,20 @@ def create_stack(new_stack: dict) -> dict:
     cf_raw_definition = None
     senza = Senza(config.region)
 
+    stack = Stack(keep_stacks=keep_stacks,
+                  traffic=new_traffic,
+                  image_version=image_version,
+                  senza_yaml=senza_yaml,
+                  stack_name=stack_name,
+                  stack_version=stack_version,
+                  application_version=application_version,
+                  parameters=parameters)
+
     try:
-        cf_raw_definition = senza.render_definition(senza_yaml, stack_version,
-                                                    image_version, parameters)
+        cf_raw_definition = senza.render_definition(senza_yaml,
+                                                    stack.stack_version,
+                                                    stack.image_version,
+                                                    parameters)
     except SenzaRenderError as exception:
         return connexion.problem(400,
                                  'Invalid senza yaml',
@@ -108,14 +119,8 @@ def create_stack(new_stack: dict) -> dict:
 
     # Create the Stack
     logger.info("Creating stack %s...", stack_name)
-    stack = Stack(keep_stacks=keep_stacks,
-                  traffic=new_traffic,
-                  image_version=image_version,
-                  senza_yaml=senza_yaml,
-                  stack_name=stack_name,
-                  stack_version=stack_version,
-                  application_version=application_version,
-                  parameters=parameters)
+    stack.stack_name = stack_name
+    stack.stack_id = stack.generate_id()
 
     if stack.application_version:
         kio_extra = {'stack_name': stack_name, 'version': application_version}

--- a/lizzy/security.py
+++ b/lizzy/security.py
@@ -13,9 +13,16 @@ def bouncer(endpoint, *args, **kwargs):
     Checks if the user making request is in the predefined list of allowed users
     """
     config = Configuration()
+
+    if not hasattr(connexion.request, 'user'):
+        logger.debug('User not found in the request',
+                     extra={'allowed_users': config.allowed_users})
+        return connexion.problem(403, 'Forbidden', "Anonymous access is not allowed in this endpoint")
+
     if config.allowed_users is not None:
         logger.debug('Checking if user is allowed',
                      extra={'user': connexion.request.user, 'allowed_users': config.allowed_users})
         if connexion.request.user not in config.allowed_users:
             return connexion.problem(403, 'Forbidden', "User is not allowed to access this endpoint")
+
     return endpoint(*args, **kwargs)


### PR DESCRIPTION
Cloud formation rendering (`senza print`) because of a missing parameter (`stack_version`) which is generated (if not provided) by an internal logic from Stack model. That was causing an error while creating a new stack.