### PR TITLE
Force print to avoid problems of authentication with kio API

### DIFF
--- a/lizzy/apps/senza.py
+++ b/lizzy/apps/senza.py
@@ -148,8 +148,10 @@ class Senza(Application):
             temp_yaml.write(senza_yaml.encode())
             temp_yaml.file.flush()
             try:
-                return self._execute('print', temp_yaml.name, stack_version,
-                                     image_version, *parameters, expect_json=True)
+                return self._execute('print', '--force',
+                                     temp_yaml.name, stack_version,
+                                     image_version, *parameters,
+                                     expect_json=True)
             except ExecutionError as e:
                 self.logger.error('Failed to render CloudFormation defition.',
                                   extra={'command.output': e.output})

--- a/tests/test_senza_wrapper.py
+++ b/tests/test_senza_wrapper.py
@@ -244,7 +244,7 @@ def test_render_definition(monkeypatch, popen):
     senza.render_definition('yaml content', 'version42', 'imgversion22',
                             ['Param1=app', 'SecondParam=3'])
 
-    cmd = 'senza print --region region -o json lizzy.yaml version42 ' \
+    cmd = 'senza print --region region -o json --force lizzy.yaml version42 ' \
           'imgversion22 Param1=app SecondParam=3'
 
     popen.assert_called_with(cmd.split(" "), stdout=-1, stderr=-1)


### PR DESCRIPTION
If there is a problem with authentication with kio de `senza print` should still print the CF file.