### PR TITLE
Support taupage auto scaling group with any name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import re
 import ast
+import re
 import sys
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
 
 _version_re = re.compile(r'VERSION\s+=\s+(.*)')
 
-MINOR_VERSION = 1
+MINOR_VERSION = 2
 
 with open('lizzy/version.py', 'rb') as f:
     version_content = f.read().decode('utf-8')

--- a/tests/fixtures/cloud_formation.py
+++ b/tests/fixtures/cloud_formation.py
@@ -23,6 +23,54 @@ GOOD_CF_DEFINITION = {
     }
 }
 
+GOOD_CF_DEFINITION_WITH_UNUSUAL_AUTOSCALING_RESOURCE = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Mappings": {
+        "Senza": {
+            "Info": {
+                "StackName": "abc",
+                "StackVersion": "2"
+            }
+        }
+    },
+    "Parameters": {},
+    "Resources": {
+        "NiceClusterConfig": {
+            "Properties": {
+                "ImageId": "image-id",
+                "InstanceType": "t2.micro",
+                "UserData": {
+                    "Fn::Base64": "#taupage-config\napplication_id: abc\nsource: pierone.example.com/lizzy/lizzy:12\n"
+                }
+            },
+            "Type": "AWS::AutoScaling::LaunchConfiguration"
+        }
+    }
+}
+
+BAD_CF_MISSING_TAUPAGE_AUTOSCALING_GROUP = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Mappings": {
+        "Senza": {
+            "Info": {
+                "StackName": "abc",
+                "StackVersion": "2"
+            }
+        }
+    },
+    "Parameters": {},
+    "Resources": {
+        "AppServerConfig": {
+            "Properties": {
+                "ImageId": "image-id",
+                "InstanceType": "t2.micro",
+                "UserData": {}
+            },
+            "Type": "AWS::Else"
+        }
+    }
+}
+
 BAD_CF_DEFINITION = {
     "AWSTemplateFormatVersion": "2010-09-09",
     "Mappings": {


### PR DESCRIPTION
The [TaupageAutoScalingGroup](https://github.com/zalando-stups/senza/blob/master/senza/components/taupage_auto_scaling_group.py#L36) component of Senza can have [any name](https://github.com/zalando-stups/senza/blob/master/senza/components/taupage_auto_scaling_group.py#L69-L71).

This PR fix that going through all resources in the CloudFormation definition and looking for a resource with type ["AWS::AutoScaling::LaunchConfiguration"](https://github.com/zalando-stups/senza/blob/master/senza/components/auto_scaling_group.py#L12-L14) since that is the type senza attributes to [this kind of component](https://github.com/zalando-stups/senza/blob/master/senza/components/taupage_auto_scaling_group.py#L40).