### PR TITLE
Secure "not found" paths

### DIFF
--- a/lizzy/api.py
+++ b/lizzy/api.py
@@ -235,3 +235,8 @@ def delete_stack(stack_id: str) -> dict:
                                      headers=_make_headers())
 
     return '', 204, _make_headers()
+
+
+def not_found_path_handler(error):
+    return connexion.problem(401, 'Unauthorized',
+                             "No authorization token provided")

--- a/lizzy/api.py
+++ b/lizzy/api.py
@@ -238,5 +238,4 @@ def delete_stack(stack_id: str) -> dict:
 
 
 def not_found_path_handler(error):
-    return connexion.problem(401, 'Unauthorized',
-                             "No authorization token provided")
+    return connexion.problem(401, 'Unauthorized', '')

--- a/lizzy/service.py
+++ b/lizzy/service.py
@@ -8,6 +8,7 @@ import connexion
 import lizzy.configuration as configuration
 import rod.connection
 import uwsgi_metrics
+from lizzy.api import not_found_path_handler
 
 logger = logging.getLogger('lizzy')
 
@@ -22,6 +23,10 @@ def setup_webapp(config: configuration.Configuration):  # pragma: no cover
                         arguments=arguments,
                         auth_all_paths=True)
     app.add_api('lizzy.yaml')
+
+    flask_app = app.app
+    flask_app.errorhandler(404)(not_found_path_handler)
+
     return app
 
 

--- a/lizzy/service.py
+++ b/lizzy/service.py
@@ -2,11 +2,12 @@
 
 # The functions in this module all have `pragma: no cover` because they only setup stuff and don't do "real" work
 
-import connexion
 import logging
+
+import connexion
+import lizzy.configuration as configuration
 import rod.connection
 import uwsgi_metrics
-import lizzy.configuration as configuration
 
 logger = logging.getLogger('lizzy')
 

--- a/lizzy/swagger/lizzy.yaml
+++ b/lizzy/swagger/lizzy.yaml
@@ -24,6 +24,9 @@ securityDefinitions:
     scopes:
         "{{deployer_scope}}": Can deploy and change stacks
 
+security:
+  - oauth: []
+
 paths:
   /stacks:
     get:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -129,6 +129,9 @@ def test_security(app, oauth_requests):
     invalid_access = app.get('/api/does-not-exist')
     assert invalid_access.status_code == 401
 
+    invalid_access = app.get('/random-access-that-does-not-exist-outside-of-api')
+    assert invalid_access.status_code == 401
+
 
 def test_empty_new_stack(monkeypatch, app, oauth_requests):
     data = {}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -123,6 +123,12 @@ def test_security(app, oauth_requests):
     assert get_stacks.status_code == 200
     assert get_stacks.headers['X-Lizzy-Version'] == CURRENT_VERSION
 
+    inexistent_url = app.get('/api/does-not-exist', headers=GOOD_HEADERS)
+    assert inexistent_url.status_code == 403
+
+    invalid_access = app.get('/api/does-not-exist')
+    assert invalid_access.status_code == 401
+
 
 def test_empty_new_stack(monkeypatch, app, oauth_requests):
     data = {}


### PR DESCRIPTION
A global security configuration was missing in Lizzy so we could have hidden/protected authenticated "not found" paths (404). This PR fixes that.

Still there it is necessary an improvement in Connexion to support global protected "not found" paths.