### PR TITLE
fix 400 errors on lizzy traffic

### DIFF
--- a/lizzy/apps/common.py
+++ b/lizzy/apps/common.py
@@ -14,7 +14,8 @@ class Application:  # pylint: disable=too-few-public-methods
         self.extra_parameters = extra_parameters or []  # type: Iterable[str]
 
     def _execute(self, subcommand: str, *args: Iterable[str],
-                 expect_json: bool=False):
+                 expect_json: bool=False,
+                 accept_empty: bool=True):
         command = [self.application, subcommand]
         command.extend(self.extra_parameters)
         if expect_json:
@@ -30,11 +31,13 @@ class Application:  # pylint: disable=too-few-public-methods
         stdout, _ = process.communicate()
         output = stdout.decode()
         if process.returncode == 0:
-            if expect_json:
+            if expect_json and (output or not accept_empty):
                 try:
                     return json.loads(output)
                 except ValueError:
                     raise ExecutionError('JSON ERROR', output)
+            elif not output and not accept_empty:
+                raise ExecutionError('EMPTY OUTPUT', output)
             else:
                 return output
         else:

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,0 +1,70 @@
+import pytest
+from unittest.mock import MagicMock
+import json
+
+from lizzy.apps.common import Application
+from lizzy.exceptions import ExecutionError
+
+
+@pytest.fixture
+def popen(monkeypatch):
+    mock_popen = MagicMock()
+    mock_popen.return_value = mock_popen
+    mock_popen.returncode = 0
+    monkeypatch.setattr('lizzy.apps.common.Popen', mock_popen)
+    return mock_popen
+
+
+def test_json_output(monkeypatch, popen):
+    expected = {"foo": "bar"}
+    popen.communicate.return_value = json.dumps(expected).encode(), b'stderr'
+
+    app = Application("foo")
+    output = app._execute("bar", "a", "b", "c", expect_json=True, accept_empty=True)
+    assert output == expected
+
+    output = app._execute("bar", "a", "b", "c", expect_json=False, accept_empty=True)
+    assert output == json.dumps(expected)
+
+    output = app._execute("bar", "a", "b", "c", expect_json=True, accept_empty=False)
+    assert output == expected
+
+    output = app._execute("bar", "a", "b", "c", expect_json=False, accept_empty=False)
+    assert output == json.dumps(expected)
+
+
+def test_empty_output(monkeypatch, popen):
+    expected = ""
+    popen.communicate.return_value = expected.encode(), b'stderr'
+
+    app = Application("foo")
+
+    output = app._execute("bar", "a", "b", "c", expect_json=False, accept_empty=True)
+    assert output == expected
+
+    output = app._execute("bar", "a", "b", "c", expect_json=True, accept_empty=True)
+    assert output == expected
+
+    with pytest.raises(ExecutionError):
+        app._execute("bar", "a", "b", "c", expect_json=True, accept_empty=False)
+
+    with pytest.raises(ExecutionError):
+        app._execute("bar", "a", "b", "c", expect_json=False, accept_empty=False)
+
+
+def test_invalid_json_output(monkeypatch, popen):
+    expected = "[[}"
+    popen.communicate.return_value = expected.encode(), b'stderr'
+
+    app = Application("foo")
+    output = app._execute("bar", "a", "b", "c", expect_json=False, accept_empty=True)
+    assert output == expected
+
+    output = app._execute("bar", "a", "b", "c", expect_json=False, accept_empty=False)
+    assert output == expected
+
+    with pytest.raises(ExecutionError):
+        app._execute("bar", "a", "b", "c", expect_json=True, accept_empty=False)
+
+    with pytest.raises(ExecutionError):
+        app._execute("bar", "a", "b", "c", expect_json=True, accept_empty=True)


### PR DESCRIPTION
We experienced some 400 errors when issuing lizzy traffic <STACK> <STACK_VERSION> 0 on the last existing stack:

```
11:51:00 + lizzy version
11:51:00 Lizzy Client 1.8
11:51:00 + lizzy traffic <> 0
11:51:01 Fetching authentication token.. . OK

11:51:01 Requesting traffic change..Data Json:
11:51:05  EXCEPTION OCCURRED: 400 Client Error: BAD REQUEST for url: https://lizzy-nuggad.nuggad.zalan.do/api/stacks/zk-kafka-3
11:51:05 {
11:51:05     "new_traffic": 0
11:51:05 }
11:51:05 Traceback (most recent call last):
11:51:05   File "/usr/local/bin/lizzy", line 11, in <module>
11:51:05     sys.exit(main())
11:51:05   File "/usr/local/lib/python3.4/dist-packages/click/core.py", line 716, in __call__
11:51:05     return self.main(*args, **kwargs)
11:51:05   File "/usr/local/lib/python3.4/dist-packages/click/core.py", line 696, in main
11:51:05     rv = self.invoke(ctx)
11:51:05   File "/usr/local/lib/python3.4/dist-packages/click/core.py", line 1060, in invoke
11:51:05     return _process_result(sub_ctx.command.invoke(sub_ctx))
11:51:05   File "/usr/local/lib/python3.4/dist-packages/click/core.py", line 889, in invoke
11:51:05     return ctx.invoke(self.callback, **ctx.params)
11:51:05   File "/usr/local/lib/python3.4/dist-packages/click/core.py", line 534, in invoke
11:51:05     return callback(*args, **kwargs)
11:51:05   File "/usr/local/lib/python3.4/dist-packages/lizzy_client/cli.py", line 207, in traffic
11:51:05     lizzy.traffic(stack_id, percentage)
11:51:05   File "/usr/local/lib/python3.4/dist-packages/lizzy_client/lizzy.py", line 126, in traffic
11:51:05     request.raise_for_status()
11:51:05   File "/usr/local/lib/python3.4/dist-packages/requests/models.py", line 840, in raise_for_status
11:51:05     raise HTTPError(http_error_msg, response=self)
```

It seems lizzy expects JSON output but does not accept empty output. In the case described above, senza outputs nothing: https://github.com/zalando-stups/senza/blob/master/senza/traffic.py#L343 

This PR contains a fix for that edge case.