### PR TITLE
Add more ways of approval of PRs

### DIFF
--- a/.zappr.yml
+++ b/.zappr.yml
@@ -2,7 +2,7 @@ approvals:
   # PR needs at least 1 approvals
   minimum: 1
   # approval = comment that matches this regex
-  pattern: "^:\\+1:$"
+  pattern: "^(:\\+1:|👍|LGTM)$"
   from:
     # commenter must be either one of:
     # a public zalando org member


### PR DESCRIPTION
After the change in how GitHub API returns the content of comments in PR we need to update the ZAPPR config to allow other characters to the approval REGEX.