### PR TITLE
Expose senza errors to lizzy-client

### DIFF
--- a/lizzy/api.py
+++ b/lizzy/api.py
@@ -84,7 +84,8 @@ def create_stack(new_stack: dict) -> dict:
         missing_property = str(exception)
         problem = connexion.problem(400,
                                     'Invalid senza yaml',
-                                    "Missing property in senza yaml: {}".format(missing_property),
+                                    "Missing property in senza yaml: {}".format(
+                                        missing_property),
                                     headers=_make_headers())
         return problem
 
@@ -92,25 +93,18 @@ def create_stack(new_stack: dict) -> dict:
     logger.info("Creating stack %s...", stack_name)
 
     senza = Senza(config.region)
-    stack_extra = {'stack_name': stack_name,
-                   'stack_version': stack_version,
-                   'image_version': image_version,
-                   'parameters': parameters}
     tags = {'LizzyKeepStacks': keep_stacks,
             'LizzyTargetTraffic': new_traffic}
-    try:
-        senza.create(senza_yaml, stack_version, image_version, parameters,
-                     disable_rollback, tags)
-    except ExecutionError as error:
-        logger.error("Error creating stack.", extra=stack_extra)
-        return connexion.problem(400,
-                                 title='Failed to create stack',
-                                 detail=error.output,
-                                 headers=_make_headers())
-    else:
-        logger.info("Stack created.", extra=stack_extra)
-        stack_dict = Stack.get(stack_name, stack_version)
-        return stack_dict, 201, _make_headers()
+
+    senza.create(senza_yaml, stack_version, image_version, parameters,
+                 disable_rollback, tags)
+
+    logger.info("Stack created.", extra={'stack_name': stack_name,
+                                         'stack_version': stack_version,
+                                         'image_version': image_version,
+                                         'parameters': parameters})
+    stack_dict = Stack.get(stack_name, stack_version)
+    return stack_dict, 201, _make_headers()
 
 
 @bouncer
@@ -143,41 +137,22 @@ def patch_stack(stack_id: str, stack_patch: dict) -> dict:
         # Change the AMI image of the Auto Scaling Group (ASG) and respawn the
         # instances to use new image.
         new_ami_image = stack_patch['new_ami_image']
-        try:
-            senza.patch(stack_name, stack_version, new_ami_image)
-            senza.respawn_instances(stack_name, stack_version)
-        except ExecutionError as exception:
-            logger.info(exception.message, extra=log_info)
-            return connexion.problem(400, 'Image update failed',
-                                     exception.message,
-                                     headers=_make_headers())
+        senza.patch(stack_name, stack_version, new_ami_image)
+        senza.respawn_instances(stack_name, stack_version)
 
     if 'new_traffic' in stack_patch:
         new_traffic = stack_patch['new_traffic']
-        try:
-            domains = senza.domains(stack_name)
-            if domains:
-                logger.info("Switching app traffic to stack.",
-                            extra=log_info)
-                senza.traffic(stack_name=stack_name,
-                              stack_version=stack_version,
-                              percentage=new_traffic)
-            else:
-                logger.info("App does not have a domain so traffic will not be switched.",
-                            extra=log_info)
-                raise TrafficNotUpdated("App does not have a domain.")
-        except SenzaDomainsError as exception:
-            logger.exception(
-                "Failed to get domains. Traffic will not be switched.",
-                extra=log_info)
-            return connexion.problem(400, 'Traffic update failed',
-                                     exception.message,
-                                     headers=_make_headers())
-        except SenzaTrafficError as exception:
-            logger.exception("Failed to switch app traffic.", extra=log_info)
-            return connexion.problem(400, 'Traffic update failed',
-                                     exception.message,
-                                     headers=_make_headers())
+        domains = senza.domains(stack_name)
+        if domains:
+            logger.info("Switching app traffic to stack.",
+                        extra=log_info)
+            senza.traffic(stack_name=stack_name,
+                          stack_version=stack_version,
+                          percentage=new_traffic)
+        else:
+            logger.info("App does not have a domain so traffic will not be switched.",
+                        extra=log_info)
+            raise TrafficNotUpdated("App does not have a domain.")
 
     # refresh the dict
     stack_dict = Stack.get(stack_name, stack_version)

--- a/lizzy/api.py
+++ b/lizzy/api.py
@@ -10,7 +10,6 @@ from flask import Response
 from lizzy import config
 from lizzy.apps.senza import Senza
 from lizzy.exceptions import (ExecutionError, ObjectNotFound,
-                              SenzaDomainsError, SenzaTrafficError,
                               TrafficNotUpdated)
 from lizzy.models.stack import Stack
 from lizzy.security import bouncer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,9 @@
+import logging
+
+import pytest
 from fixtures.senza import mock_senza  # NOQA
+
+
+@pytest.fixture(scope='session')
+def debug_level():
+    logging.getLogger().setLevel(logging.DEBUG)


### PR DESCRIPTION
Fixes #123 

Seems like we just need to expose all senza errors to the client then it can handle properly showing the error to the users in form of command output. If I understand correctly removing the server-side senza commands errors handing and letting it go to the client should be enough.