### PR TITLE
Remove unused parameter from API

### DIFF
--- a/lizzy/swagger/lizzy.yaml
+++ b/lizzy/swagger/lizzy.yaml
@@ -269,14 +269,9 @@ definitions:
       image_version:
         type: string
         description: Docker image version to deploy
-      application_version:
-        type: string
-        description: Version of the application to use for stack name and kio
       stack_version:
         type: string
-        description: |
-            Version of the application to use for stack name, this will
-            override the version provided in the application_version
+        description: Version of the application to use for stack name
       keep_stacks:
         type: integer
         format: int32


### PR DESCRIPTION
`application_version` is not used anymore, we can remove from release2.0 version.