### PR TITLE
Modify GET /stacks to accept stack references parameter

### DIFF
--- a/lizzy/api.py
+++ b/lizzy/api.py
@@ -43,11 +43,13 @@ def exception_to_connexion_problem(func, *args, **kwargs):
 
 @bouncer
 @exception_to_connexion_problem
-def all_stacks() -> dict:
+def all_stacks(references: str=None) -> dict:
     """
     GET /stacks/
     """
-    stacks = Stack.list()
+    if not references:
+        references = []
+    stacks = Stack.list(*references)
     stacks.sort(key=lambda stack: stack.creation_time)
     return stacks, 200, _make_headers()
 

--- a/lizzy/swagger/lizzy.yaml
+++ b/lizzy/swagger/lizzy.yaml
@@ -37,6 +37,14 @@ paths:
       security:
         - oauth:
             - "{{deployer_scope}}"
+      parameters:
+        - name: references
+          in: query
+          collectionFormat: csv
+          type: array
+          items:
+            type: string
+          required: false
       responses:
         200:
           description: List of stacks

--- a/tests/fixtures/senza.py
+++ b/tests/fixtures/senza.py
@@ -7,10 +7,15 @@ import pytest
 def mock_senza(monkeypatch):
     mock = MagicMock()
     mock.return_value = mock
-    mock.list = lambda *a, **k: [{"creation_time": 1460635167,
-                                  "description": "Lizzy Bus (ImageVersion: 257)",
-                                  "status": "CREATE_COMPLETE",
-                                  "version": "257" if not a else a[1]}]
+
+    def list_method(*a, **k):
+        return [{"creation_time": 1460635167,
+                 "description": "Lizzy Bus (ImageVersion: 257)",
+                 "stack_name": "lizzy-bus" if not a else a[0],
+                 "status": "CREATE_COMPLETE",
+                 "version": "257" if not a else a[1]}]
+
+    mock.list = MagicMock(wraps=list_method)
     mock.create = MagicMock(return_value="output")
     monkeypatch.setattr('lizzy.api.Senza', mock)
     monkeypatch.setattr('lizzy.models.stack.Senza', mock)

--- a/tests/fixtures/senza.py
+++ b/tests/fixtures/senza.py
@@ -9,7 +9,6 @@ def mock_senza(monkeypatch):
     mock.return_value = mock
     mock.list = lambda *a, **k: [{"creation_time": 1460635167,
                                   "description": "Lizzy Bus (ImageVersion: 257)",
-                                  "stack_name": "lizzy-bus" if not a else a[0],
                                   "status": "CREATE_COMPLETE",
                                   "version": "257" if not a else a[1]}]
     mock.create = MagicMock(return_value="output")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,7 @@
 import json
 import os
 from unittest.mock import ANY, MagicMock
+from urllib.parse import quote
 
 import lizzy.api
 import pytest
@@ -295,6 +296,20 @@ def test_get_stack(app, mock_senza):
     response = json.loads(request.data.decode())  # type: dict
     keys = response.keys()
     assert parameters == keys
+
+
+def test_list_stacks(app, mock_senza):
+    response = app.get('/api/stacks', headers=GOOD_HEADERS)
+    payload = json.loads(response.data.decode())  # type: dict
+    assert len(payload) > 0
+    assert response.status_code == 200
+    mock_senza.list.assert_called_with()
+
+    response = app.get('/api/stacks?references={}'.format(quote('stack,v2')), headers=GOOD_HEADERS)
+    payload = json.loads(response.data.decode())  # type: dict
+    assert len(payload) > 0
+    assert response.status_code == 200
+    mock_senza.list.assert_called_with('stack', 'v2')
 
 
 def test_get_stack_404(app, mock_senza):


### PR DESCRIPTION
We rely on the default behaviour of Senza for stack filtering as expected by users of Lizzy.