### PR TITLE
Use snake case for payload to follow all other endpoints

### DIFF
--- a/lizzy/api.py
+++ b/lizzy/api.py
@@ -243,7 +243,7 @@ def get_app_status():
     status_info = {
         'version': os.environ.get("APPLICATION_VERSION", ""),
         'status': status,
-        'APIConfig': {
+        'config': {
             name: getattr(config, name)
             for name in dir(config) if not name.startswith('__')
         }

--- a/lizzy/swagger/lizzy.yaml
+++ b/lizzy/swagger/lizzy.yaml
@@ -292,7 +292,7 @@ paths:
                 description: Lizzy version running
               status:
                 type: string
-              APIConfig:
+              config:
                 type: object
                 properties:
                   allowed_users:


### PR DESCRIPTION
All other endpoints use snake case, just that one was not following the pattern.