### PR TITLE
Lizzy runs "senza delete" incorrectly

### DIFF
--- a/lizzy/apps/senza.py
+++ b/lizzy/apps/senza.py
@@ -87,7 +87,7 @@ class Senza(Application):
             options.append('--dry-run')
         if force:
             options.append('--force')
-        return self._execute('delete', *options, stack_id)
+        return self._execute('delete', *options, *stack_id.rsplit("-", 1))
 
     def traffic(self, stack_name: str, stack_version: Optional[str]=None,
                 percentage: Optional[int]=None) -> List[Dict]:

--- a/tests/test_senza_wrapper.py
+++ b/tests/test_senza_wrapper.py
@@ -158,11 +158,13 @@ def test_remove(popen, stack_id, region, dry_run, force):
     dry_run_flag = ['--dry-run'] if dry_run else []
     force_flag = ['--force'] if force else []
 
+    stack_name, stack_ver = stack_id.rsplit("-", 1)
+
     popen.assert_called_with(['senza', 'delete']
                              + ['--region', region]
                              + dry_run_flag
                              + force_flag
-                             + [stack_id],
+                             + [stack_name, stack_ver],
                              stdout=-1, stderr=-2)
 
     assert not senza.logger.error.called


### PR DESCRIPTION
Lizzy doesn't delete stacks with specified versions because it runs senza in the following way

`senza delete "yourstack-yourversion"
`

though, it has to

`senza delete "yourstack" "yourversion"
`

I even tried to use whitespace in url, like DELETE /stacks/stack_name%20stack_ver, but it still runs it as:

`senza delete "yourstack yourversion"
`

Perhaps, it has to work with another version of senze (the current specified one is `stups-senza>=1.0.40`.)

Anyway, there is a quick fix for the problem  in this pull request.