### PR TITLE
Use application_id from Taupage UserData for Kio version create

### DIFF
--- a/lizzy/api.py
+++ b/lizzy/api.py
@@ -110,6 +110,7 @@ def create_stack(new_stack: dict) -> dict:
                 taupage_yaml = definition['Properties']['UserData']['Fn::Base64']
                 taupage_config = yaml.safe_load(taupage_yaml)
                 artifact_name = taupage_config['source']
+                application_id = taupage_config['application_id']
 
         if artifact_name is None:
             missing_component_error = "Missing component type Senza::TaupageAutoScalingGroup"
@@ -141,7 +142,7 @@ def create_stack(new_stack: dict) -> dict:
         kio_extra = {'stack_name': stack_name, 'version': application_version}
         logger.info("Registering version on kio...", extra=kio_extra)
         kio = Kio()
-        if kio.versions_create(application_id=stack.stack_name,
+        if kio.versions_create(application_id=application_id,
                                version=stack.application_version,
                                artifact=artifact_name):
             logger.info("Version registered in Kio.", extra=kio_extra)

--- a/tests/fixtures/cloud_formation.py
+++ b/tests/fixtures/cloud_formation.py
@@ -23,6 +23,31 @@ GOOD_CF_DEFINITION = {
     }
 }
 
+GOOD_CF_DEF_WITH_DIFFERENT_APPLICATION_ID = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Mappings": {
+        "Senza": {
+            "Info": {
+                "StackName": "abc-stackname",
+                "StackVersion": "2"
+            }
+        }
+    },
+    "Parameters": {},
+    "Resources": {
+        "AppServerConfig": {
+            "Properties": {
+                "ImageId": "image-id",
+                "InstanceType": "t2.micro",
+                "UserData": {
+                    "Fn::Base64": "#taupage-config\napplication_id: abc-specific-id\nsource: pierone.example.com/lizzy/lizzy:12\n"
+                }
+            },
+            "Type": "AWS::AutoScaling::LaunchConfiguration"
+        }
+    }
+}
+
 GOOD_CF_DEFINITION_WITH_UNUSUAL_AUTOSCALING_RESOURCE = {
     "AWSTemplateFormatVersion": "2010-09-09",
     "Mappings": {


### PR DESCRIPTION
Instead of `StackName` from the Senza definition to register a new version of the application in Kio we should use the `application_id` from the Taupage UserData generated by Senza output after rendering the CloudFormation template.