### PR TITLE
Zappr validate our commit msgs

### DIFF
--- a/.zappr.yml
+++ b/.zappr.yml
@@ -10,3 +10,7 @@ approvals:
       - zalando
     # a collaborator of the repo
     collaborators: true
+commit:
+  message:
+    patterns:
+      - "#[0-9]+" # has to begin with hash # and at least one number


### PR DESCRIPTION
Lizzy should create the least number of violations in [fullstop](https://docs.stups.io/en/latest/components/fullstop.html) as possible by default.

Fixes #154 