### PR TITLE
Fix auth tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 install:
   - pip install -e .
   - pip install coveralls
-  - pip install flake8
+  - pip install flake8==2.6.2
 script:
   - python setup.py test
   - python setup.py flake8

--- a/lizzy/service.py
+++ b/lizzy/service.py
@@ -6,6 +6,7 @@
 import logging
 
 import connexion
+import werkzeug.exceptions
 
 from lizzy.api import not_found_path_handler, expose_api_schema, health_check
 from .serialization import JSONEncoder
@@ -28,7 +29,8 @@ def setup_webapp(config: configuration.Configuration):  # pragma: no cover
     flask_app = app.app
     flask_app.json_encoder = JSONEncoder
 
-    flask_app.errorhandler(404)(not_found_path_handler)
+    flask_app.register_error_handler(werkzeug.exceptions.NotFound,
+                                     not_found_path_handler)
 
     flask_app.add_url_rule('/.well-known/schema-discovery',
                            'schema_discovery_endpoint',

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pytz
 pyyaml
 stups-senza>=1.0.40
 uwsgi
-flask==0.10.1
+flask==0.11.1

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -118,7 +118,7 @@ def test_security(app, mock_senza):
     assert get_stacks.headers['X-Lizzy-Version'] == CURRENT_VERSION
 
     inexistent_url = app.get('/api/does-not-exist', headers=GOOD_HEADERS)
-    assert inexistent_url.status_code == 403
+    assert inexistent_url.status_code == 404
 
     invalid_access = app.get('/api/does-not-exist')
     assert invalid_access.status_code == 401


### PR DESCRIPTION
Fix tests failing on master. Reflects that authenticated clients requests to unknown endpoints should return `404`.

Other changes:
- Upgrade Flask to 0.11.1
- Better way to add default error handlers, new in Flask 0.11.1