### PR TITLE
Update the base docker image to 3.5.2-37

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/python:3.5.1-23
+FROM registry.opensource.zalan.do/stups/python:3.5.2-37
 
 EXPOSE 8080
 


### PR DESCRIPTION
The base docker image needs to be updated since the old one has a version of OpenSSL vulnerable to CVE-2016-6304, CVE-2016-6305, CVE-2016-2183, CVE-2016-6303, CVE-2016-6302, CVE-2016-2182, CVE-2016-2180, CVE-2016-2177, CVE-2016-2178, CVE-2016-2179, CVE-2016-2181, CVE-2016-6306, CVE-2016-6307 and CVE-2016-6308.