### PR TITLE
Try more if AWS API give error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build.py
 run.sh
 __pycache__
 .tox/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.opensource.zalan.do/stups/python:3.5.2-38
 EXPOSE 8080
 
 RUN apt-get update \
- && apt-get install -q -y --no-install-recommends m4 build-essential libssl-dev libffi-dev python-dev \
+ && apt-get install -q -y --no-install-recommends python3-venv m4 build-essential libssl-dev libffi-dev python-dev \
  && apt-get upgrade -y \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
@@ -12,7 +12,14 @@ ADD uwsgi.yaml /
 ADD setup.py /
 ADD requirements.txt /
 ADD lizzy /lizzy
-RUN pip3 install -r requirements.txt
+
+RUN python -m venv /lizzy_env
+ENV PATH=/lizzy_env/bin:$PATH
+RUN pip install -U pip setuptools wheel
+RUN pip install -r requirements.txt
+
+ADD _retry.json /.aws/models/_retry.json
+ADD _retry.json /root/.aws/models/_retry.json
 
 ADD scm-source.json /
 

--- a/_retry.json
+++ b/_retry.json
@@ -1,0 +1,215 @@
+{
+  "definitions": {
+    "throttling": {
+      "applies_when": {
+        "response": {
+          "service_error_code": "Throttling",
+          "http_status_code": 400
+        }
+      }
+    },
+    "throttling_exception": {
+      "applies_when": {
+        "response": {
+          "service_error_code": "ThrottlingException",
+          "http_status_code": 400
+        }
+      }
+    },
+    "too_many_requests": {
+      "applies_when": {
+        "response": {
+          "http_status_code": 429
+        }
+      }
+    },
+    "general_socket_errors": {
+      "applies_when": {
+        "socket_errors": ["GENERAL_CONNECTION_ERROR"]
+      }
+    },
+    "general_server_error": {
+      "applies_when": {
+        "response": {
+          "http_status_code": 500
+        }
+      }
+    },
+    "bad_gateway": {
+      "applies_when": {
+        "response": {
+          "http_status_code": 502
+        }
+      }
+    },
+    "service_unavailable": {
+      "applies_when": {
+        "response": {
+          "http_status_code": 503
+        }
+      }
+    },
+    "gateway_timeout": {
+      "applies_when": {
+        "response": {
+          "http_status_code": 504
+        }
+      }
+    },
+    "limit_exceeded": {
+      "applies_when": {
+        "response": {
+          "http_status_code": 509
+        }
+      }
+    }
+  },
+  "retry": {
+    "__default__": {
+      "max_attempts": 20,
+      "delay": {
+        "type": "exponential",
+        "base": "rand",
+        "growth_factor": 2
+      },
+      "policies": {
+          "general_socket_errors": {"$ref": "general_socket_errors"},
+          "general_server_error": {"$ref": "general_server_error"},
+          "bad_gateway": {"$ref": "bad_gateway"},
+          "service_unavailable": {"$ref": "service_unavailable"},
+          "gateway_timeout": {"$ref": "gateway_timeout"},
+          "limit_exceeded": {"$ref": "limit_exceeded"},
+          "throttling_exception": {"$ref": "throttling_exception"},
+          "throttling": {"$ref": "throttling"},
+          "too_many_requests": {"$ref": "too_many_requests"}
+      }
+    },
+    "dynamodb": {
+      "__default__": {
+        "max_attempts": 10,
+        "delay": {
+          "type": "exponential",
+          "base": 0.05,
+          "growth_factor": 2
+        },
+        "policies": {
+          "throughput_exceeded": {
+            "applies_when": {
+              "response": {
+                "service_error_code": "ProvisionedThroughputExceededException",
+                "http_status_code": 400
+              }
+            }
+          },
+          "crc32": {
+            "applies_when": {
+              "response": {
+                "crc32body": "x-amz-crc32"
+              }
+            }
+          }
+        }
+      }
+    },
+    "ec2": {
+      "__default__": {
+        "policies": {
+          "request_limit_exceeded": {
+            "applies_when": {
+              "response": {
+                "service_error_code": "RequestLimitExceeded",
+                "http_status_code": 503
+              }
+            }
+          }
+        }
+      }
+    },
+    "cloudsearch": {
+      "__default__": {
+        "policies": {
+          "request_limit_exceeded": {
+            "applies_when": {
+              "response": {
+                "service_error_code": "BandwidthLimitExceeded",
+                "http_status_code": 509
+              }
+            }
+          }
+        }
+      }
+    },
+    "kinesis": {
+      "DescribeStream": {
+        "policies": {
+          "request_limit_exceeded": {
+            "applies_when": {
+              "response": {
+                "service_error_code": "LimitExceededException",
+                "http_status_code": 400
+              }
+            }
+          }
+        }
+      }
+    },
+    "sqs": {
+      "__default__": {
+        "policies": {
+          "request_limit_exceeded": {
+            "applies_when": {
+              "response": {
+                "service_error_code": "RequestThrottled",
+                "http_status_code": 403
+              }
+            }
+          }
+        }
+      }
+    },
+    "s3": {
+      "__default__": {
+        "policies": {
+          "timeouts": {
+            "applies_when": {
+              "response": {
+                "http_status_code": 400,
+                "service_error_code": "RequestTimeout"
+              }
+            }
+          },
+          "contentmd5": {
+            "applies_when": {
+              "response": {
+                "http_status_code": 400,
+                "service_error_code": "BadDigest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "route53": {
+      "__default__": {
+        "policies": {
+          "request_limit_exceeded": {
+            "applies_when": {
+              "response": {
+                "service_error_code": "Throttling",
+                "http_status_code": 400
+              }
+            }
+          },
+          "still_processing": {
+            "applies_when": {
+              "response": {
+                "service_error_code": "PriorRequestNotComplete",
+                "http_status_code": 400
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Override the default `botocore`'s `_retry.json` policy file to retry more in case AWS API give error (https://github.com/boto/botocore/issues/882#issuecomment-210631172).

May be removed after/if https://github.com/boto/botocore/pull/891 gets merged.

We add in both paths `/.aws/*` and `/root/.aws/*` because Taupage run the docker image as [unprivileged user](https://github.com/zalando-stups/taupage/blob/6ab57826fa9a6128239/runtime/opt/taupage/runtime/Docker.py#L229-L232).