### PR TITLE
Wait for long running commands to finish

### DIFF
--- a/uwsgi.yaml
+++ b/uwsgi.yaml
@@ -1,5 +1,6 @@
 uwsgi:
     http: 0.0.0.0:8080
+    http-timeout: 120
     module: lizzy.wsgi
     logformat : UWSGI: %(method) %(uri) -> %(status)
     threads: 4


### PR DESCRIPTION
Some Senza commands like `senza delete <stackid>` takes long to run, let uWSGI wait a little longer for these requests. 