### PR TITLE
Extend timeout to 5 minutes

### DIFF
--- a/uwsgi.yaml
+++ b/uwsgi.yaml
@@ -1,6 +1,6 @@
 uwsgi:
     http: 0.0.0.0:8080
-    http-timeout: 120
+    http-timeout: 300
     module: lizzy.wsgi
     logformat : UWSGI: %(method) %(uri) -> %(status)
     threads: 4


### PR DESCRIPTION
AWS still taking more time to delete some stacks in our project, So we would like to extend the timeout to a maximum 5 minutes.